### PR TITLE
Update to Guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~5.1"
+        "guzzlehttp/guzzle": "~6.0"
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -32,11 +32,10 @@ class Client
     {
         if (null === $this->client) {
             $this->client = new \GuzzleHttp\Client([
-                'defaults' => [
-                    'headers' => [
-                        'Authorization' => $this->token
-                    ]
-                ]
+              'base_uri' => 'https://api.pexels.com/v1/',
+              'headers' => [
+                'Authorization' => $this->token
+              ]
             ]);
         }
 
@@ -52,10 +51,10 @@ class Client
      */
     public function search($query, $size = 15, $page = 1)
     {
-        return $this->getClient()->get('http://api.pexels.com/v1/search?'.http_build_query([
+        return $this->getClient()->get('search?'.http_build_query([
             'query' => $query,
             'per_page' => $size,
             'page' => $page
-        ]));
+          ]));
     }
 }


### PR DESCRIPTION
This required changes to the Client constructor: Clients are immutable in Guzzle 6, which means that you cannot change the defaults used by a client after it's created. The client constructor will need to be passed the base_uri option.
Closes #4.