### PR TITLE
Update to Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr-4": { "Glooby\\Pexels\\": "src/" }
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0"
     }
 }


### PR DESCRIPTION
Guzzle 7 dropped support for PHP 5 and requires PHP 7.2. (I'm not sure if this package would still work with PHP 5, in case composer is smart enough to keep installing Guzzle 6 in that case.) There do not appear to be any other breaking changes here.

Thanks a lot for your work!